### PR TITLE
Create boot.properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ dist/
 *.paw
 *-local.edn
 gpg.edn
-boot.properties

--- a/boot.properties
+++ b/boot.properties
@@ -1,0 +1,5 @@
+#http://boot-clj.com
+#Fri Sep 27 08:02:52 NZST 2019
+BOOT_VERSION=2.8.2
+BOOT_CLOJURE_VERSION=1.9.0
+BOOT_CLOJURE_NAME=org.clojure/clojure


### PR DESCRIPTION
Because:
- This controls which version of Clojure and boot is used when running
the project locally and in CI.

This commit:
- Unignores boot.properties
- Creates a boot.properties file with a Clojure version that matches
what is in the build.boot file.